### PR TITLE
Revert "Add github.com/qvisten999/scd30.git version v1.1.0"

### DIFF
--- a/packages/github.com/qvisten999/scd30.git/1.1.0/desc.yaml
+++ b/packages/github.com/qvisten999/scd30.git/1.1.0/desc.yaml
@@ -1,7 +1,0 @@
-name: scd30
-description: Driver for the Sensirion SCD30 sensor module, for monitoring CO2, temperature,
-  and humidity.
-license: MIT
-url: github.com/qvisten999/scd30.git
-version: 1.1.0
-hash: 90d521fdbb7f935d0e1ae75938ba99650d2f8ce8


### PR DESCRIPTION
This reverts commit d3a4f519be764ec33a40d183a27548619702382d.

This was an accidental publish of a package with the
".git" at the end, which creates duplicate packages.