### PR TITLE
Remove toit-hs-sr04

### DIFF
--- a/packages/github.com/lask/toit-hs-sr04/1.0.0/desc.yaml
+++ b/packages/github.com/lask/toit-hs-sr04/1.0.0/desc.yaml
@@ -1,6 +1,0 @@
-name: toit_hs_sr04
-description: Driver for the HS-SR04 ultrasonic ranging module.
-license: MIT
-url: github.com/lask/toit-hs-sr04
-version: 1.0.0
-hash: 4ba4769e913b4c02aa926eaa38ccb40c3c343a13

--- a/packages/github.com/lask/toit-hs-sr04/1.0.1/desc.yaml
+++ b/packages/github.com/lask/toit-hs-sr04/1.0.1/desc.yaml
@@ -1,6 +1,0 @@
-name: hs_sr04
-description: Driver for the HS-SR04 ultrasonic ranging module.
-license: MIT
-url: github.com/lask/toit-hs-sr04
-version: 1.0.1
-hash: 3523a0c9879da0e16052e4b7e06f94adc536fd09

--- a/packages/github.com/lask/toit-hs-sr04/1.0.2/desc.yaml
+++ b/packages/github.com/lask/toit-hs-sr04/1.0.2/desc.yaml
@@ -1,6 +1,0 @@
-name: hs_sr04
-description: Driver for the HS-SR04 ultrasonic ranging module.
-license: MIT
-url: github.com/lask/toit-hs-sr04
-version: 1.0.2
-hash: 32164e2d20bd1d33a60f0d45cb5d0677e3ac8b24

--- a/packages/github.com/lask/toit-hs-sr04/1.1.0/desc.yaml
+++ b/packages/github.com/lask/toit-hs-sr04/1.1.0/desc.yaml
@@ -1,6 +1,0 @@
-name: hs_sr04
-description: Driver for the HS-SR04 ultrasonic ranging module.
-license: MIT
-url: github.com/lask/toit-hs-sr04
-version: 1.1.0
-hash: 29331821743d8631975c809c3a28c80bcc45719d

--- a/packages/github.com/lask/toit-hs-sr04/1.1.1/desc.yaml
+++ b/packages/github.com/lask/toit-hs-sr04/1.1.1/desc.yaml
@@ -1,6 +1,0 @@
-name: hs_sr04
-description: Driver for the HS-SR04 ultrasonic ranging module.
-license: MIT
-url: github.com/lask/toit-hs-sr04
-version: 1.1.1
-hash: 4d27ab2e41139ed9815e0e6ba2950ab470d97019


### PR DESCRIPTION
This package has been replaced by toit-hc-sr04 (with the correct name).