### PR TITLE
Add close2/toit-dartino-regexp v0.4.1

### DIFF
--- a/packages/github.com/close2/toit-dartino-regexp/0.4.1/desc.yaml
+++ b/packages/github.com/close2/toit-dartino-regexp/0.4.1/desc.yaml
@@ -1,0 +1,10 @@
+name: dartino_regexp
+description: A port of Dartino's regexp engine to Toit (close2 fork).
+url: github.com/close2/toit-dartino-regexp
+version: 0.4.1
+environment:
+  sdk: ^2.0.0-alpha.161
+hash: 768fed0da7102530356c5f94f2d373546892697a
+dependencies:
+- url: github.com/toitlang/pkg-case
+  version: ^0.2.0


### PR DESCRIPTION
Adds a fork of `erikcorry/toit-dartino-regexp` that includes a one-line fix for a compile error on the latest Toit SDK (v2.0.0-alpha.193+).

Upstream issue: `assert: equivalence <= 3` in `src/regexp.toit:1031` compares a `List` to an `int`. The fix changes it to `equivalence.size <= 3`.

Upstream PR (already filed): https://github.com/erikcorry/toit-dartino-regexp/pull/12

Adding the fork here unblocks downstream projects until upstream is updated.